### PR TITLE
Fix bug with keyorder when value is false

### DIFF
--- a/dkjson.lua
+++ b/dkjson.lua
@@ -319,7 +319,7 @@ encode2 = function (value, indent, level, buffer, buflen, tables, globalorder, s
         for i = 1, n do
           local k = order[i]
           local v = value[k]
-          if v then
+          if v ~= nil then
             used[k] = true
             buflen, msg = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
             prev = true -- add a seperator before the next element


### PR DESCRIPTION
Running the following:
```lua
json.encode({A = 0, B = false, C = 0}, {keyorder = {"B", "A", "C"}})
```
Results:
**without** this patch: ```"{"A":0,"C":0,"B":false}"```
**with** this patch: ```"{"B":false,"A":0,"C":0}"```